### PR TITLE
Added password and challenge/response handling for Winlink 

### DIFF
--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -83,6 +83,7 @@ _DEF_PREFS = {
     "msg_wl2k_server" : "server.winlink.org",
     "msg_wl2k_ssid" : "",
     "msg_wl2k_port" : "8772",
+    "msg_wl2k_password" : "",
     "toolbar_button_size" : "Default",
     "check_spelling" : "False",
     "confirm_exit" : "False",
@@ -1215,7 +1216,10 @@ class DratsMessagePanel(DratsPanel):
         prt = DratsConfigWidget(config, "prefs", "msg_wl2k_port")
         prt.add_numeric(1, 65535, 1)
         lab = gtk.Label(_("Port"))
-        self.mv(_("WL2K Network Server"), srv, lab, prt)
+        pwd = DratsConfigWidget(config, "prefs", "msg_wl2k_password")
+        pwd.add_pass()
+        ptab = gtk.Label(_("Password"))
+        self.mv(_("WL2K Network Server"), srv, lab, prt, ptab, pwd)
 
         rms = DratsConfigWidget(config, "prefs", "msg_wl2k_rmscall")
         rms.add_upper_text(10)

--- a/d_rats/wl2k.py
+++ b/d_rats/wl2k.py
@@ -240,7 +240,6 @@ class WinLinkCMS:
             raise Exception("Conversation error (unparsable SSID `%s')" % resp)
 
         self._send(self.__ssid())
-
         prompt = self._recv().strip()
         if not prompt.endswith(">"):
             raise Exception("Conversation error (never got prompt)")
@@ -251,7 +250,6 @@ class WinLinkCMS:
         msgs = []
         reading = True
         while reading:
-            resp = self._recv()
             resp = self._recv()
             for l in resp.split("\r"):
                 if l.startswith("FC"):


### PR DESCRIPTION
Added the challenge/response handling as defined for WinLink2k.
Also, I added a new password field under Preferences/Messages next to the WL2K server.
(I can not test since I am not allowed to send e-mails to WinLink.org - such nice people)
Message receive via WL2K should now work...
