### PR TITLE
Correction on some file unlock exceptions

### DIFF
--- a/d_rats/msgrouting.py
+++ b/d_rats/msgrouting.py
@@ -279,7 +279,8 @@ class MessageRouter(gobject.GObject):
             del form
 
             if not call:
-                msg_unlock(f)
+                if msg_is_locked(f):
+                    msg_unlock(f)
                 continue
             elif not queue.has_key(call):
                 queue[call] = [f]
@@ -507,7 +508,8 @@ class MessageRouter(gobject.GObject):
                     routed = False
     
                 if not routed:
-                    msg_unlock(msg)
+                    if msg_is_locked(msg):
+                        msg_unlock(msg)
     
     def _run(self):
         while self.__enabled:
@@ -524,7 +526,8 @@ class MessageRouter(gobject.GObject):
                     for msgs in queue.values():
                         for msg in msgs:
                             print "Unlocking %s" % msg
-                            msg_unlock(msg)
+                            if msg_is_locked(msg):
+                                msg_unlock(msg)
 
                 self.__event.clear()
             self.__event.wait(self.__config.getint("settings", "msg_flush"))

--- a/d_rats/ui/main_messages.py
+++ b/d_rats/ui/main_messages.py
@@ -940,6 +940,9 @@ class MessagesTab(MainWindowTab):
 
         self.emit("user-send-form", station, port, fn, "foo")
 
+        if msgrouting.msg_is_locked(fn):
+            msgrouting.msg_unlock(fn)
+
     def _mrk_msg(self, button, read):
         try:
             sel = self._messages.get_selected_messages()


### PR DESCRIPTION
In some cases, there are unlock requests on unlock files. Set all unlocks to check for existing locks before unlocking.