### PR TITLE
Removed Windows system DLLs

### DIFF
--- a/distXP.bat
+++ b/distXP.bat
@@ -20,33 +20,33 @@ rem D-Rats also depends from these OS c:libraries,
 rem which in theory should be inovked from the OS and not distributed 
 rem but by trial and errors need to be added to the package otherwise 
 rem it will not work correctly
-xcopy C:\WINDOWS\system32\ADVAPI32.dll  dist /y
-xcopy C:\WINDOWS\system32\COMDLG32.dll  dist /y
-xcopy C:\WINDOWS\system32\COMCTL32.dll  dist /y
-xcopy C:\WINDOWS\system32\CRYPT32.dll   dist /y
+rem xcopy C:\WINDOWS\system32\ADVAPI32.dll  dist /y
+rem xcopy C:\WINDOWS\system32\COMDLG32.dll  dist /y
+rem xcopy C:\WINDOWS\system32\COMCTL32.dll  dist /y
+rem xcopy C:\WINDOWS\system32\CRYPT32.dll   dist /y
 
-xcopy C:\WINDOWS\system32\GDI32.dll     dist /y
-xcopy C:\WINDOWS\system32\gdiplus.dll   dist /y
+rem xcopy C:\WINDOWS\system32\GDI32.dll     dist /y
+rem xcopy C:\WINDOWS\system32\gdiplus.dll   dist /y
 
-xcopy C:\WINDOWS\system32\KERNEL32.dll  dist /y
+rem xcopy C:\WINDOWS\system32\KERNEL32.dll  dist /y
 
-xcopy C:\WINDOWS\system32\MPR.dll       dist /y
-xcopy C:\WINDOWS\system32\msvcrt.dll    dist /y
-xcopy C:\WINDOWS\system32\MSIMG32.DLL   dist /y
-xcopy C:\WINDOWS\system32\MSWSOCK.dll   dist /y
+rem xcopy C:\WINDOWS\system32\MPR.dll       dist /y
+rem xcopy C:\WINDOWS\system32\msvcrt.dll    dist /y
+rem xcopy C:\WINDOWS\system32\MSIMG32.DLL   dist /y
+rem xcopy C:\WINDOWS\system32\MSWSOCK.dll   dist /y
 
 
-xcopy C:\WINDOWS\system32\OLE32.dll     dist /y
-xcopy C:\WINDOWS\system32\OLEAUT32.dll  dist /y
+rem xcopy C:\WINDOWS\system32\OLE32.dll     dist /y
+rem xcopy C:\WINDOWS\system32\OLEAUT32.dll  dist /y
 
-xcopy C:\WINDOWS\system32\SHELL32.DLL   dist /y
-xcopy C:\WINDOWS\system32\SHLWAPI.DLL   dist /y
+rem xcopy C:\WINDOWS\system32\SHELL32.DLL   dist /y
+rem xcopy C:\WINDOWS\system32\SHLWAPI.DLL   dist /y
 
-xcopy C:\WINDOWS\system32\USER32.dll    dist /y
-xcopy C:\WINDOWS\system32\USP10.DLL    dist /y
-xcopy C:\WINDOWS\system32\VERSION.dll   dist /y
-xcopy C:\WINDOWS\system32\WINMM.dll     dist /y
-xcopy C:\WINDOWS\system32\WINSPOOL.DRV  dist /y
+rem xcopy C:\WINDOWS\system32\USER32.dll    dist /y
+rem xcopy C:\WINDOWS\system32\USP10.DLL     dist /y
+rem xcopy C:\WINDOWS\system32\VERSION.dll   dist /y
+rem xcopy C:\WINDOWS\system32\WINMM.dll     dist /y
+rem xcopy C:\WINDOWS\system32\WINSPOOL.DRV  dist /y
 
 
 rem D-Rats also depends from these libraries, but shall not be distributed as otherwise will 

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,11 @@ def win32_build():
                               'API-MS-Win-Core-String-L1-1-0.dll' ,
                               'API-MS-Win-Core-Synch-L1-1-0.dll' ,
                               'API-MS-Win-Core-SysInfo-L1-1-0.dll',
-                              'DNSAPI.dll',
-                              'NSI.dll'
+                              'DNSAPI.DLL',
+                              'MSIMG32.DLL',
+                              'MSWSOCK.dll',
+                              'NSI.DLL' ,
+                              'USP10.DLL'
                             ] ,
             "compressed" : 1,
             "optimize" : 2,


### PR DESCRIPTION
The system DLLs are different on various Windows releases, preventing the proper startup.
The user should take care of their proper installation.