### PR TITLE
Corrections for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ INSTALL ON LINUX (contrib & credit Marius Petrescu)
 
 The installation steps are quite easy (assuming one has all the neede python libs installed):
 
-via package installer: python-glade2, python-libxml2, pythhon-libxslt1
-via pip: pyserial
+via package installer: python-glade2, python-libxml2, python-libxslt1, python-serial
 
 After this, the steps are as follows:
 

--- a/linux/d-rats_repeater_service
+++ b/linux/d-rats_repeater_service
@@ -9,8 +9,8 @@
 # Should-Stop:       $network $named slapd autofs ypbind nscd nslcd winbind
 # Default-Start:     2 3 4 5
 # Default-Stop:
-# Short-Description: D-Rats Repater
-# Description:       D-Rats Repater is a repeater for D-Rats
+# Short-Description: D-Rats Repeater
+# Description:       D-Rats Repeater is a repeater for D-Rats
 ### END INIT INFO
 
 # Service Config

--- a/linux/d-rats_repeater_service
+++ b/linux/d-rats_repeater_service
@@ -1,9 +1,17 @@
 #!/bin/bash
-#########################################################
-#                                                       #
-#           D-Rats Repeater Service Handler             #
-#                                                       #
-#########################################################
+# Start/stop the d-rats_repeater.
+#
+### BEGIN INIT INFO
+# Provides:          d-rats_repeater
+# Required-Start:    $remote_fs $syslog $time
+# Required-Stop:     $remote_fs $syslog $time
+# Should-Start:      $network $named slapd autofs ypbind nscd nslcd winbind
+# Should-Stop:       $network $named slapd autofs ypbind nscd nslcd winbind
+# Default-Start:     2 3 4 5
+# Default-Stop:
+# Short-Description: D-Rats Repater
+# Description:       D-Rats Repater is a repeater for D-Rats
+### END INIT INFO
 
 # Service Config
 DAEMON=d-rats_repeater.py
@@ -75,3 +83,4 @@ case "$1" in
                 echo $"Usage: $0 {start|stop|restart|status}"
                 exit 1
 esac
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires = python-glade2, python-libxml2, python-libxslt1, pyserial
+requires = python-glade2, python-libxml2, python-libxslt1, python-serial


### PR DESCRIPTION
- updated the reflector startup script to be usable on recent systemd based distributions
('systemctl enable d-rats_repeater_service' will not complain about runlevels missing)
- updated the setup.cfg file with the correct package name for python-serial
- updated Readme to remove references to installing pyserial via pip.

