### PR TITLE
dded a default "?" icon on positions received with no icon so to have…

### DIFF
--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -171,18 +171,18 @@ class MainApp(object):
         # Prepare string to broadcast to internet browsers clients
         message = '{ "lat": "%f", "lng": "%f", "station": "%s", "comments": "%s","timestamp": "%s"  }' % (flat, flng, station, comments, strftime("%Y-%m-%d %H:%M:%S", gmtime()))
 
-        print(("Mainapp   : preparing our gpsfix to send around:", message))
+        print("Mainapp   : preparing our gpsfix in JSON :", message)
 
         try:
             #create an AF_INET, STREAM socket (TCP)
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         except socket.error as msg:
-            print(('Mainapp   :  Failed to create socket. Error code: ' + str(msg[0]) + ' , Error message : ' + msg[1]))
+            print('Mainapp   :  Failed to create socket. Error code: ' + str(msg[0]) + ' , Error message : ' + msg[1])
             raise
         print('Mainapp   :  Socket Created')
 
         #Connect to remote server
-        print(("Mainapp   :  Connecting to: ", mapserver_ip, ":", mapserver_port))
+        print("Mainapp   :  Connecting to: ", mapserver_ip, ":", mapserver_port)
         try:
             #create an AF_INET, STREAM socket (TCP)
             s.connect((mapserver_ip , mapserver_port))
@@ -820,8 +820,13 @@ class MainApp(object):
                                        fix.latitude,
                                        fix.longitude,
                                        fix.altitude,
-                                       fix.comment)
-        point.set_icon_from_aprs_sym(fix.APRSIcon)
+                                       fix.comment)        
+        if fix.APRSIcon == None:
+            point.set_icon_from_aprs_sym('\?')
+            print("gps       : APRSIcon missing - forced to: \? ")
+        else:
+            point.set_icon_from_aprs_sym(fix.APRSIcon)
+            
         source.add_point(point)
         source.save()
         

--- a/d_rats/version.py
+++ b/d_rats/version.py
@@ -8,7 +8,7 @@
 from __future__ import print_function
 import sys
 
-DRATS_VERSION = "0.3.9 beta 2 "
+DRATS_VERSION = "0.3.9 beta 3 "
 DRATS_NAME="d-rats"
 DRATS_DESCRIPTION="D-RATS"
 DRATS_LONG_DESCRIPTION = "A communications tool for D-STAR"
@@ -16,7 +16,7 @@ AUTHORS = "Dan Smith, KK7DS" +chr(13)+ \
           "Maurizio Andreotti, IZ2LXI" +chr(13)+ \
           "Marius Petrescu, YO2LOJ"
 AUTHORS_EMAIL= "Dan Smith KK7DS <dsmith@danplanet.com>;" +chr(13)+ \
-          "Maurizio Andreotti IZ2LXI <maurizioandreottilc@gmail.com>" +chr(13)+ \
+          "Maurizio Andreotti IZ2LXI <maurizio.iz2lxi@gmail.com>" +chr(13)+ \
           "Marius Petrescu YO2LOJ <marius@yo2loj.ro>"
 COPYRIGHT ="Copyright 2010 Dan Smith (KK7DS)" +chr(13)+ \
           "Copyright 2014-2020 Maurizio Andreotti (IZ2LXI) &" +chr(13)+ \


### PR DESCRIPTION
While installing version 0.3.9 beta 2 for Window 10, I encountered the following problems:
1.  The openweathermap function kept returning an SSL Certificate Validation Failed error in the debug.log and would not display the weather information.
Solution:  In the Cordana search bar type "Internet Options".  When it comes up, go to the Security section and make sure Use SSL 3.0 is checked.  Then go into D-Rats Preferences, Chat, and remove the https:// on the openweathermap.org URL and replace with http:// with the s removed.  Reboot the system and reload.  Under QSTs create an OpenWeather QST.  You must use the format "city name,state,country in order for it to work properly.  Be aware if calling for forecasts instead of the current weather condition the return will be extensive.

2.  On getting the program to work properly with Gmail, some new users should experience little to no problems if setting up to use a new, or relatively empty email account.  I had been using D-Rats for about 6 years and the email account I had been using had become a bit cluttered.  The new install attempted to download the entire email database from Gmail, approximately 350 messages or so.  The program could not handle the load, so I created a new account and everything started working again.  To use Gmail, you must use smtp.gmail.com, port 587 and turn on TLS for Outgoing Mail in Preferences.  For Email Accounts, create an account as pop.gmail.com, your email address and password, Poll Interval 2, Check Use SSL, Port 995, Action Form, and finally check Enable.

3.  **Issues with maps.**  To use the maps, the BaseMap server URL needed to be changed from https;//a.tile.openstreetmap.org/ to https://a.tile.openstreetmap.de/.  The .org site would not work.  In order to use the other maps, cycle, landscape, or outdoors, you must first go to thunderforest.com and obtain their free API.  The API string should read "?apikey=" followed by the API you obtain from their site.  Report position timestamps on map should remain off unless you are wanting to use D-Rats in a mobile environment as it will create too much data.

4.  **Using D-Rats with Winlink.**  You have to already have your Callsign@winlink.org account set up in order to use this feature.  Once you have it, copy your Winlink email address and password into the appropriate sections of Preferences, Messages.
To send an email to another station that YOU KNOW has a Winlink account address the message n the Destination Callsign as "WL2K: Callsign".  On the Subject line place "//WL2K" and then the message subject.  This way the program knows to send the message out via Winlink and having the //WL2K in the subject line lets Winlink know it is not a Spam message that they should refuse to accept.   If you want to use Winlink to send a message to a regular email address, you just need the //WL2K in the subject line to send the message,  You may get a confirmation response depending on how you have your account at Winlink set up.  Be aware that D-Rats uses the Internet to send messages to Winlink via Telnet.  If the Internet goes down in your area you would need to revert to an RF means of sending the messages using Winlink Express in Windows or one of the other Winlink clients to send the message either by Packet or HF.

I hope these tips will help you get your D-Rats station up and running with no problems.