### PR TITLE
Python3 compatibility fixes

### DIFF
--- a/d_rats/comm.py
+++ b/d_rats/comm.py
@@ -145,7 +145,7 @@ class SWFSerial(serial.Serial):
         printlog("Comm","        : Software XON/XOFF control initialized")
         try:
             serial.Serial.__init__(self, **kwargs)
-        except TypeError:
+        except TypeError as e:
             if "writeTimeout" in kwargs:
                 del kwargs["writeTimeout"]
                 serial.Serial.__init__(self, **kwargs)

--- a/d_rats/dplatform.py
+++ b/d_rats/dplatform.py
@@ -26,7 +26,11 @@ from .debug import printlog
 import os
 import sys
 import glob
-import commands
+try:
+    # pylint: disable=import-error
+    import commands
+except ModuleNotFoundError:
+    pass
 import subprocess
 import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 from six.moves import range

--- a/d_rats/mainapp.py
+++ b/d_rats/mainapp.py
@@ -903,7 +903,13 @@ class MainApp(object):
     
     def __station_status(self, object, sta, stat, msg, port):
         self.mainwindow.tabs["stations"].saw_station(sta, port, stat, msg)
-        status = station_status.get_status_msgs()[stat]
+        try:
+            status = station_status.get_status_msgs()[stat]
+        except KeyError:
+            printlog("Mainapp","    : Invalid station_status of %d." %
+                     stat)
+            status="code %d" % stat
+
         event = main_events.Event(None,
                                   "%s %s %s %s: %s" % (_("Station"),
                                                        sta,

--- a/d_rats/platform.py
+++ b/d_rats/platform.py
@@ -25,7 +25,11 @@ from .debug import printlog
 import os
 import sys
 import glob
-import commands
+try:
+    # pylint: disable=import-error
+    import commands
+except ModuleNotFoundError:
+    pass
 import subprocess
 import six.moves.urllib.request, six.moves.urllib.parse, six.moves.urllib.error
 from six.moves import range


### PR DESCRIPTION
Fix the ddt2, dplatform, platform, transport, and yencode.py modules
in the d_rats directory to work for both python3 and python2.

d_rats/comm.py: Fix exception coding.
d_rats/mainapp.py: Patch to handle and display out of range status code.

The of range status code was produced by connecting two d-rats instances
through serial ports as a test to make sure that serial connections
work, so someplace there is a bug where the status code is not getting
initialized.