### PR TITLE
Mapdisplay and geocode_ui test fixes

### DIFF
--- a/d_rats/version.py
+++ b/d_rats/version.py
@@ -23,7 +23,8 @@ AUTHORS_EMAIL= "Dan Smith KK7DS <dsmith@danplanet.com>;" +chr(13)+ \
           "Marius Petrescu YO2LOJ <marius@yo2loj.ro>"
 COPYRIGHT ="Copyright 2010 Dan Smith (KK7DS)" +chr(13)+ \
           "Copyright 2014-2020 Maurizio Andreotti (IZ2LXI) &" +chr(13)+ \
-          "Marius Petrescu (YO2LOJ)"
+          "Marius Petrescu (YO2LOJ)" + chr(13) + \
+		  "Location and Map data Copyright OpenStreetMap Contributors"
 LICENCE ="You should have received a copy of the GNU General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>."
 WEBSITE = "https://groups.io/g/d-rats"
 TRANSLATIONS  ="Italian: Leo, IZ5FSA"


### PR DESCRIPTION
Fix the unit tests for the geocode_ui and mapdisplay modules.

Yahoo is no longer providing geocode lookups.

Switched to using OSM's Nomninatim geocode lookup wervice and to prefer
to use the distribution or PyPi geopy package over the embedded geopy
package.  In the future the embedded geopy package should get removed.

python2 -m d_rats.geocode_ui

python2 -m d_rats.mapdisplay

Add the OSMF required attribution to the copyright information.

Still todo is to implement a replacement for the missing set_marker
method for the tests.