### PR TITLE
rpc.py bytearray fix

### DIFF
--- a/d_rats/sessions/rpc.py
+++ b/d_rats/sessions/rpc.py
@@ -66,6 +66,10 @@ def decode_dict(string):
             k, v = element.split(ASCII_US)
         except ValueError:
             raise Exception("Malformed dict encoding")
+        # sockets and pipe routines return bytearray type
+        # which on python2 is almost the same str type, but not quite.
+        if isinstance(k, bytearray):
+            k = k.decode('ISO-8859-1')
         result[k] = v
 
     return result


### PR DESCRIPTION
Bug fix for a previous commit.

The rpc encode_dict routine has to be able to handle getting a bytearray
as the input string for compatibilty with python3.