### PR TITLE
config gps_default_message fix

### DIFF
--- a/d_rats/config.py
+++ b/d_rats/config.py
@@ -149,7 +149,7 @@ _DEF_SETTINGS = {
     "keyformapurllandscape": "?apikey=5a1a4a79354244a38707d83969fd88a2",
     
     #GPS
-    "default_gps_comment" : "BN  *20",     #default icon for our station in the map and gpsfixes
+    "default_gps_comment" : "BN  ",     #default icon for our station in the map and gpsfixes
     "map_marker_bgcolor": "yellow",        #background color for markers in the map window
     
     "warmup_length" : "16",                 #changed from 8 to 16 in 0.3.6


### PR DESCRIPTION
Remove the "*20" from the gps default message.
The asterisk character is used by DPRS to start the checksum so its
presence here causes d-rats to flood the console with mesages since
the checksum does not match.

Not sure if the trailing spaces are still needed, that can be handled
in a later commit.